### PR TITLE
Feature 메뉴 주문 가능한지도 response 에 담아서 전달

### DIFF
--- a/server/src/main/java/nior_near/server/domain/store/application/StoreQueryService.java
+++ b/server/src/main/java/nior_near/server/domain/store/application/StoreQueryService.java
@@ -5,6 +5,6 @@ import nior_near.server.global.common.BaseResponseDto;
 
 public interface StoreQueryService {
 
-    public BaseResponseDto<StoreResponseDto> getStore(Long storeId);
+    BaseResponseDto<StoreResponseDto> getStore(Long storeId);
 
 }

--- a/server/src/main/java/nior_near/server/domain/store/dto/response/StoreResponseDto.java
+++ b/server/src/main/java/nior_near/server/domain/store/dto/response/StoreResponseDto.java
@@ -31,6 +31,7 @@ public class StoreResponseDto {
         private String menuIntroduction;
         private Long menuPrice;
         private Integer menuGram;
+        private boolean isOrderable;
 
         public MenuItem(Menu menu) {
             this.menuId = menu.getId();
@@ -39,6 +40,7 @@ public class StoreResponseDto {
             this.menuIntroduction = menu.getIntroduction();
             this.menuPrice = menu.getPrice();
             this.menuGram = menu.getOneServing();
+            this.isOrderable = menu.isStock();
         }
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : getStore 기능에서 해당 메뉴가 주문 가능한 상태인지에 대한 데이터도 같이 전달하도록 추가

### 변경사항 및 이유

- 변경 사항 : Response 에 orderable 값 추가하여 전달
- 해당 메뉴가 주문 가능한 상태인지 전달하여 주문할 때, 주문 못하는 상태인 메뉴 주문을 막기 위해서

### 테스트

- 포스트맨, h2 테스트 결과 이상 없음