### PR TITLE
FEAT: 기본 프로필 조회에서 편지 조회 가능

### DIFF
--- a/server/src/main/java/nior_near/server/domain/user/application/MemberServiceImpl.java
+++ b/server/src/main/java/nior_near/server/domain/user/application/MemberServiceImpl.java
@@ -1,6 +1,8 @@
 package nior_near.server.domain.user.application;
 
 import lombok.RequiredArgsConstructor;
+import nior_near.server.domain.letter.application.LetterService;
+import nior_near.server.domain.letter.dto.response.LetterResponseDto;
 import nior_near.server.domain.user.dto.response.MyMemberResponseDto;
 import nior_near.server.domain.user.entity.Member;
 import nior_near.server.domain.user.exception.handler.MemberExceptionHandler;
@@ -8,15 +10,20 @@ import nior_near.server.domain.user.repository.MemberRepository;
 import nior_near.server.global.common.ResponseCode;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-    private final int MyPageLettersLimit = 3;
+    private final LetterService letterService;
 
     @Override
     public MyMemberResponseDto getMyProfile() {
+
+        final int MY_PAGE_LETTER_LIMIT = 3;
+        final int DEFAULT_PAGE = 0;
 
         // TODO: JWT Token으로 member 정보 가져오기
         long memberId = 0;
@@ -24,13 +31,14 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberExceptionHandler(ResponseCode.MEMBER_NOT_FOUND));
 
-        // TODO: getAllLetters 메서드에 limit 매개변수를 추가하고 LetterDtos를 가져옴.
+        List<LetterResponseDto> letters = letterService.getAllLetters(DEFAULT_PAGE, MY_PAGE_LETTER_LIMIT);
 
         return MyMemberResponseDto.builder()
                 .memberId(memberId)
                 .nickname(member.getName())
                 .point(member.getPoint())
                 .imageUrl(member.getProfileImage())
+                .letterResponseDtos(letters)
                 .build();
     }
 }

--- a/server/src/main/java/nior_near/server/domain/user/dto/response/MyMemberResponseDto.java
+++ b/server/src/main/java/nior_near/server/domain/user/dto/response/MyMemberResponseDto.java
@@ -2,7 +2,9 @@ package nior_near.server.domain.user.dto.response;
 
 import lombok.Builder;
 import lombok.Data;
-import nior_near.server.domain.user.entity.Member;
+import nior_near.server.domain.letter.dto.response.LetterResponseDto;
+
+import java.util.List;
 
 @Data
 @Builder
@@ -12,15 +14,5 @@ public class MyMemberResponseDto {
     private String nickname;
     private long point;
     private String imageUrl;
-    // TODO: 편지함 Dtos 추가
-
-    public static MyMemberResponseDto of(Member member) {
-
-        return MyMemberResponseDto.builder()
-                .memberId(member.getId())
-                .nickname(member.getName())
-                .point(member.getPoint())
-                .imageUrl(member.getProfileImage())
-                .build();
-    }
+    private List<LetterResponseDto> letterResponseDtos;
 }


### PR DESCRIPTION
- 기본 프로필 조회 시 멤버 정보와 함께 3개의 쿠폰 정보도 조회가 가능합니다.
- PostMan과 h2를 활용해서 테스트 완료했습니다.