### PR TITLE
:sparkles: Feat: 지역 리스트 api 구현

### DIFF
--- a/server/src/main/java/nior_near/server/domain/store/api/RegionController.java
+++ b/server/src/main/java/nior_near/server/domain/store/api/RegionController.java
@@ -7,10 +7,7 @@ import nior_near.server.domain.store.dto.response.RegionsGetResponseDto;
 import nior_near.server.domain.store.entity.Region;
 import nior_near.server.global.common.BaseResponseDto;
 import nior_near.server.global.common.ResponseCode;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -50,5 +47,11 @@ public class RegionController {
                         .upperRegions(upperRegionsDto)
                         .detailRegions(detailRegionsDto)
                 .build(), ResponseCode.OK);
+    }
+
+    @GetMapping("/{regionId}")
+    public BaseResponseDto<Region> getRegionById(@PathVariable Long regionId) {
+        Region region = regionService.getRegionById(regionId);
+        return BaseResponseDto.onSuccess(region, ResponseCode.OK);
     }
 }

--- a/server/src/main/java/nior_near/server/domain/store/api/RegionController.java
+++ b/server/src/main/java/nior_near/server/domain/store/api/RegionController.java
@@ -1,0 +1,54 @@
+package nior_near.server.domain.store.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nior_near.server.domain.store.application.RegionService;
+import nior_near.server.domain.store.dto.response.RegionsGetResponseDto;
+import nior_near.server.domain.store.entity.Region;
+import nior_near.server.global.common.BaseResponseDto;
+import nior_near.server.global.common.ResponseCode;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/regions")
+public class RegionController {
+    private final RegionService regionService;
+
+    @GetMapping("")
+    public BaseResponseDto<RegionsGetResponseDto> getRegions(@RequestParam(required = false) Long upperId) {
+        /**
+            upperId가 -1이면, 상위 카테고리
+            upperId가 0 이상이면, 하위 카테고리
+            upperId가 NULL이면, default값 처리
+        */
+        List<Region> upperRegions = regionService.getRegionsByUpperId(-1L);
+        List<Region> detailRegions = regionService.getRegionsByUpperId(upperId);
+
+        List<RegionsGetResponseDto.Region> upperRegionsDto = upperRegions.stream()
+                .map(region -> RegionsGetResponseDto.Region.builder()
+                        .id(region.getId())
+                        .name(region.getName())
+                        .build())
+                .collect(Collectors.toList());
+
+        List<RegionsGetResponseDto.Region> detailRegionsDto = detailRegions.stream()
+                .map(region -> RegionsGetResponseDto.Region.builder()
+                        .id(region.getId())
+                        .name(region.getName())
+                        .build())
+                .collect(Collectors.toList());
+
+        return BaseResponseDto.onSuccess(RegionsGetResponseDto.builder()
+                        .upperRegions(upperRegionsDto)
+                        .detailRegions(detailRegionsDto)
+                .build(), ResponseCode.OK);
+    }
+}

--- a/server/src/main/java/nior_near/server/domain/store/application/RegionService.java
+++ b/server/src/main/java/nior_near/server/domain/store/application/RegionService.java
@@ -1,0 +1,9 @@
+package nior_near.server.domain.store.application;
+
+import nior_near.server.domain.store.entity.Region;
+
+import java.util.List;
+
+public interface RegionService {
+    public List<Region> getRegionsByUpperId(Long upperId);
+}

--- a/server/src/main/java/nior_near/server/domain/store/application/RegionService.java
+++ b/server/src/main/java/nior_near/server/domain/store/application/RegionService.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface RegionService {
     public List<Region> getRegionsByUpperId(Long upperId);
+
+    public Region getRegionById(Long regionId);
 }

--- a/server/src/main/java/nior_near/server/domain/store/application/RegionServiceImpl.java
+++ b/server/src/main/java/nior_near/server/domain/store/application/RegionServiceImpl.java
@@ -1,0 +1,23 @@
+package nior_near.server.domain.store.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nior_near.server.domain.store.entity.Region;
+import nior_near.server.domain.store.repository.RegionRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegionServiceImpl implements RegionService {
+    private final RegionRepository regionRepository;
+
+    public List<Region> getRegionsByUpperId(Long upperId) {
+        if (upperId == null) {
+            upperId = 1L; // Default upperId = 1 (서울)
+        }
+        return regionRepository.findByUpperId(upperId);
+    }
+}

--- a/server/src/main/java/nior_near/server/domain/store/application/RegionServiceImpl.java
+++ b/server/src/main/java/nior_near/server/domain/store/application/RegionServiceImpl.java
@@ -3,10 +3,13 @@ package nior_near.server.domain.store.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nior_near.server.domain.store.entity.Region;
+import nior_near.server.domain.store.exception.handler.StoreHandler;
 import nior_near.server.domain.store.repository.RegionRepository;
+import nior_near.server.global.common.ResponseCode;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -19,5 +22,10 @@ public class RegionServiceImpl implements RegionService {
             upperId = 1L; // Default upperId = 1 (서울)
         }
         return regionRepository.findByUpperId(upperId);
+    }
+
+    public Region getRegionById(Long regionId) {
+        Optional<Region> region = regionRepository.findById(regionId);
+        return region.orElseThrow(() -> new StoreHandler(ResponseCode.REGION_NOT_FOUND));
     }
 }

--- a/server/src/main/java/nior_near/server/domain/store/dto/response/RegionsGetResponseDto.java
+++ b/server/src/main/java/nior_near/server/domain/store/dto/response/RegionsGetResponseDto.java
@@ -1,0 +1,20 @@
+package nior_near.server.domain.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RegionsGetResponseDto {
+    private List<Region> upperRegions;
+    private List<Region> detailRegions;
+
+    @Getter
+    @Builder
+    public static class Region {
+        private Long id;
+        private String name;
+    }
+}

--- a/server/src/main/java/nior_near/server/domain/store/repository/RegionRepository.java
+++ b/server/src/main/java/nior_near/server/domain/store/repository/RegionRepository.java
@@ -3,5 +3,8 @@ package nior_near.server.domain.store.repository;
 import nior_near.server.domain.store.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RegionRepository extends JpaRepository<Region, Long> {
+    List<Region> findByUpperId(Long upperId);
 }

--- a/server/src/main/java/nior_near/server/global/common/ResponseCode.java
+++ b/server/src/main/java/nior_near/server/global/common/ResponseCode.java
@@ -60,7 +60,7 @@ public enum ResponseCode {
     MENU_NOT_FOUND(HttpStatus.BAD_REQUEST, "MENU4001", "해당 메뉴는 메뉴 목록에 없는 메뉴입니다."),
 
     // Region Error
-    REGION_NOT_FOUND(HttpStatus.BAD_REQUEST, "REGION4001", "카테고리에 없는 지역입니다."),
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4001", "카테고리에 없는 지역입니다."),
 
     // Place Error
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "카테고리에 없는 픽업 장소입니다."),


### PR DESCRIPTION
- [x] RegionController
- [x] RegionService
- [x] RegionsGetResponseDto
- [x] RegionRepository

### Regions에서 upperId가 -1이면, 상위 카테고리임을 나타냄
- default값을 처리하기 위해 변경
- upperId가 null이면, default값 처리

### id 기반 지역검색 api 구현
- member에 저장된 region에 대해 처리하기 용이